### PR TITLE
Remove unused coverlet.collector package

### DIFF
--- a/EulerLibTests/EulerLibTests.csproj
+++ b/EulerLibTests/EulerLibTests.csproj
@@ -19,7 +19,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="10.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EulerLib\EulerLib.csproj" />


### PR DESCRIPTION
## Summary
- `coverlet.collector` was a PackageReference in `EulerLibTests` but no code coverage was being collected anywhere — CI (`.github/workflows/dotnet.yml`) runs `dotnet test` without `--collect`, and there are no `.runsettings` or other coverage configs in the repo.
- Removing it stops the recurring Dependabot churn (#83, #85, etc.).

## Test plan
- [x] `dotnet build Euler.sln` succeeds
- [x] `dotnet test EulerLibTests/EulerLibTests.csproj` — 433 passed, 1 skipped (pre-existing), 0 failed

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)